### PR TITLE
docs: fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 #### [📃 Check out our todo list here!](https://github.com/catppuccin/discord-bot/projects/1)
 
-Based on [DiscordX](https://github.com/oceanroleplay/discord.ts) for typescript support with [Discord.js](https://github.com/discordjs/discord.js) as the underlying architechture.
+Based on [DiscordX](https://github.com/oceanroleplay/discord.ts) for typescript support with [Discord.js](https://github.com/discordjs/discord.js) as the underlying architecture.
 Please refer to the documentation or [DiscordX Templates](https://github.com/oceanroleplay/discordx-templates) for examples.
 
 ## ⚙️ Usage


### PR DESCRIPTION
Rename ‘architechture’ to ‘architecture’.